### PR TITLE
ci: move workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci:
     # Public repo canary after enabling org runner-group access.
-    runs-on: [self-hosted, linux, x64, personal, prometheus]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
## Problem

The self-hosted Prometheus x64 runner pool has been removed. Jobs in this repo
targeted `[self-hosted, linux, x64, personal, prometheus]`, which now matches
zero runners — they queue indefinitely rather than failing, so the breakage is
silent.

## Change

Retargets all jobs to `ubuntu-latest`.

## Why GitHub-hosted rather than the ARM64 Mac runner pool

This is a **public** repository. Self-hosted runners on public repos allow a
pull request from a fork to execute arbitrary code on the runner host — GitHub
explicitly advises against the combination. Public repos stay on GitHub-hosted;
private repos keep using the self-hosted pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)